### PR TITLE
Allow different `quote_via` functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ for Python projects, e.g. when you need a high-load queue consumer or high-load 
 
 Supports Python versions 3.8, 3.9, 3.10, 3.11, 3.12.
 
+Supported and tested Amazon-like SQS providers: Amazon, VK Cloud.
+
 ----
 
 ## Why aiosqs?

--- a/aiosqs/__init__.py
+++ b/aiosqs/__init__.py
@@ -10,4 +10,4 @@ from aiosqs.types import (
     SendMessageResponse,
 )
 
-VERSION = "1.0.4"
+VERSION = "1.0.5"

--- a/aiosqs/client.py
+++ b/aiosqs/client.py
@@ -80,7 +80,7 @@ class SQSClient:
         # Create the canonical query string. Important notes:
         # - Query string values must be URL-encoded (space=%20).
         # - The parameters must be sorted by name.
-        canonical_querystring = urllib.parse.urlencode(list(sorted(params.items())), quote_via=self.quote_via)
+        canonical_querystring = urllib.parse.urlencode(query=list(sorted(params.items())), quote_via=self.quote_via)
 
         # Create the canonical headers and signed headers.
         canonical_headers = f"host:{self.host}" + "\n" + f"x-amz-date:{amz_date}" + "\n"

--- a/e2e/test_e2e.py
+++ b/e2e/test_e2e.py
@@ -1,5 +1,6 @@
 import unittest
 import logging
+from urllib.parse import quote_plus
 
 from dotenv import dotenv_values
 
@@ -29,6 +30,7 @@ class E2ETestCase(unittest.IsolatedAsyncioTestCase):
             host=self.host,
             verify_ssl=False,
             logger=logger,
+            quote_via=quote_plus,
         )
 
     async def asyncTearDown(self):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ Source = "https://github.com/d3QUone/aiosqs"
 
 [tool.poetry]
 name = "aiosqs"
-version = "1.0.4"
+version = "1.0.5"
 description = "Python asynchronous and lightweight SQS client."
 authors = ["Vladimir Kasatkin <vladimirkasatkinbackend@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION
There are many different hosting providers that implement Amazon interface. And it turns out that different providers parse URL query different ways. So we must support different encoding flavors for different providers. 

- Fix: https://github.com/d3QUone/aiosqs/issues/13